### PR TITLE
Edits to the JOSS bibliography

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -41,7 +41,7 @@ archivePrefix = {arXiv},
 
 @Article{Hunter:2007,
   Author    = {Hunter, J. D.},
-  Title     = {Matplotlib: A 2D graphics environment},
+  Title     = "{Matplotlib: A 2D graphics environment}",
   Journal   = {Computing in Science \& Engineering},
   Volume    = {9},
   Number    = {3},
@@ -79,8 +79,8 @@ archivePrefix = {arXiv},
 }
 
 @software{reback2020pandas,
-    author       = {The pandas development team},
-    title        = {pandas-dev/pandas: Pandas},
+    author       = {{The pandas development team}},
+    title        = "{pandas-dev/pandas: Pandas}",
     month        = feb,
     year         = 2020,
     publisher    = {Zenodo},
@@ -134,26 +134,6 @@ Volume = {156},
 Year = 2018,
 Bdsk-Url-1 = {https://doi.org/10.3847/1538-3881/aabc4f}}
 
-@book{oliphant2006guide,
- title={A guide to NumPy},
- author={Oliphant, Travis E},
- volume={1},
- year={2006},
- publisher={Trelgol Publishing USA}
-}
-
-@article{van2011numpy,
-  title={The NumPy array: a structure for efficient numerical computation},
-  author={Van Der Walt, Stefan and Colbert, S Chris and Varoquaux, Gael},
-  journal={Computing in Science \& Engineering},
-  volume={13},
-  number={2},
-  pages={22},
-  year={2011},
-  publisher={IEEE Computer Society},
-  doi={10.1109/mcse.2011.37}
-}
-
 @ARTICLE{hotan2004,
        author = {{Hotan}, A.~W. and {van Straten}, W. and {Manchester}, R.~N.},
         title = "{PSRCHIVE and PSRFITS: An Open Approach to Radio Pulsar Data Storage and Analysis}",
@@ -173,7 +153,7 @@ archivePrefix = {arXiv},
 }
 
  @article{van2014scikit,
-  title={scikit-image: image processing in Python},
+  title="{scikit-image: image processing in Python}",
   author={Van der Walt, Stefan and Sch{\"o}nberger, Johannes L and Nunez-Iglesias, Juan and Boulogne, Fran{\c{c}}ois and Warner, Joshua D and Yager, Neil and Gouillart, Emmanuelle and Yu, Tony},
   journal={PeerJ},
   volume={2},
@@ -184,7 +164,7 @@ archivePrefix = {arXiv},
 
 @inproceedings{numba,
 author = {Lam, Siu Kwan and Pitrou, Antoine and Seibert, Stanley},
-title = {Numba: A LLVM-Based Python JIT Compiler},
+title = "{Numba: A LLVM-Based Python JIT Compiler}",
 year = {2015},
 isbn = {9781450340052},
 publisher = {Association for Computing Machinery},
@@ -262,5 +242,28 @@ archivePrefix = {arXiv},
         month = jan,
        adsurl = {https://ui.adsabs.harvard.edu/abs/2012PhDT.......418B},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@Article{         harris2020,
+ title         = {Array programming with {NumPy}},
+ author        = {Charles R. Harris and K. Jarrod Millman and St{'{e}}fan J.
+                 van der Walt and Ralf Gommers and Pauli Virtanen and David
+                 Cournapeau and Eric Wieser and Julian Taylor and Sebastian
+                 Berg and Nathaniel J. Smith and Robert Kern and Matti Picus
+                 and Stephan Hoyer and Marten H. van Kerkwijk and Matthew
+                 Brett and Allan Haldane and Jaime Fern{'{a}}ndez del
+                 R{'{\i}}o and Mark Wiebe and Pearu Peterson and Pierre
+                 G{'{e}}rard-Marchant and Kevin Sheppard and Tyler Reddy and
+                 Warren Weckesser and Hameer Abbasi and Christoph Gohlke and
+                 Travis E. Oliphant},
+ year          = {2020},
+ month         = sep,
+ journal       = {Nature},
+ volume        = {585},
+ number        = {7825},
+ pages         = {357--362},
+ doi           = {10.1038/s41586-020-2649-2},
+ publisher     = {Springer Science and Business Media {LLC}},
+ url           = {https://doi.org/10.1038/s41586-020-2649-2}
 }
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -95,7 +95,7 @@ commonly used language within Astronomy. It also comes with comprehensive
  
 
 `Your` uses the matplotlib library [@Hunter:2007] for plotting, and also makes use of various 
-numpy [@oliphant2006guide; @van2011numpy], scipy [@2020SciPy], scikit-image [@van2014scikit], numba [@numba] and 
+numpy [@harris2020], scipy [@2020SciPy], scikit-image [@van2014scikit], numba [@numba] and 
 Pandas [@reback2020pandas; @pandas2010] functions. `Your` also leverages several functions in the 
 Astropy package [@astropy:2013; @astropy:2018]: fits (astropy.io.fits), units (astropy.units), 
 coordinates (astropy.coordinates) and time (astropy.time). 


### PR DESCRIPTION
This PR includes some small formatting tweaks for the `.bib` file and it updates the Numpy citation to the currently recommended paper: https://numpy.org/citing-numpy/