### PR TITLE
Update psrdada-python URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ python setup.py install
 ``` 
 
 **Note**:
-    To use the `psrdada` format, you would need to install [psrdada-python](https://github.com/AA-ALERT/psrdada-python). [`your_heimdall.py`](https://thepetabyteproject.github.io/your/bin/your_heimdall/) requires [Heimdall](https://sourceforge.net/projects/heimdall-astro/) and [psrdada-python](https://github.com/AA-ALERT/psrdada-python). 
+    To use the `psrdada` format, you would need to install [psrdada-python](https://github.com/TRASAL/psrdada-python). [`your_heimdall.py`](https://thepetabyteproject.github.io/your/bin/your_heimdall/) requires [Heimdall](https://sourceforge.net/projects/heimdall-astro/) and [psrdada-python](https://github.com/TRASAL/psrdada-python). 
     To run the tests you would need to install `pytest`. 
 
 

--- a/your/formats/dada.py
+++ b/your/formats/dada.py
@@ -7,7 +7,7 @@ from psrdada import Writer
 logger = logging.getLogger(__name__)
 
 """
-To use `psrdada` you would first need to install [psrdada-python](https://github.com/AA-ALERT/psrdada-python).
+To use `psrdada` you would first need to install [psrdada-python](https://github.com/TRASAL/psrdada-python).
 """
 
 


### PR DESCRIPTION
The Github organization hosting psrdada-python was renamed from AA-ALERT to TRASAL. I updated the README and dada.py files to use the new URL. The old URL should also keep working for now.