### PR TITLE
added in ability to specify the dm range for dmt plots

### DIFF
--- a/your/candidate.py
+++ b/your/candidate.py
@@ -364,7 +364,7 @@ class Candidate(Your):
                 )
             return ts
 
-    def dmtime(self, dmsteps=256, target="CPU"):
+    def dmtime(self, dmsteps=256, target='CPU', range_dm=0):
         """
         Generates DM-time array of the candidate by dedispersing at adjacent DM values. Saves the data in `self.dmt`.
 
@@ -376,14 +376,16 @@ class Candidate(Your):
             target (str): 'CPU' to run the code on the CPU or 'GPU' to run it on a GPU.
 
         """
-        if target == "CPU":
-            range_dm = self.dm
+        if target == 'CPU':
+            if range_dm==0:
+                #if range_dm isn't specified, then set to dm
+                range_dm = self.dm
             dm_list = self.dm + np.linspace(-range_dm, range_dm, dmsteps)
             self.dmt = np.zeros((dmsteps, self.data.shape[0]), dtype=np.float32)
             for ii, dm in enumerate(dm_list):
                 self.dmt[ii, :] = self.dedispersets(dms=dm)
         elif target == "GPU":
-            gpu_dmt(self, device=self.device)
+            gpu_dmt(self, device=self.device, range_dm=range_dm)
         return self
 
     def get_snr(self, time_series=None):

--- a/your/utils/gpu.py
+++ b/your/utils/gpu.py
@@ -64,7 +64,7 @@ def gpu_dedisperse(cand, device=0):
     return cand
 
 
-def gpu_dmt(cand, device=0):
+def gpu_dmt(cand,device=0,range_dm=0):
     """
 
     GPU DM-Time bow-tie (by rolling the array)
@@ -79,7 +79,10 @@ def gpu_dmt(cand, device=0):
     """
     cuda.select_device(device)
     chan_freqs = cuda.to_device(np.array(cand.chan_freqs, dtype=np.float32))
-    dm_list = cuda.to_device(np.linspace(0, 2 * cand.dm, 256, dtype=np.float32))
+    if range_dm ==0:
+        dm_list = cuda.to_device(np.linspace(0, 2 * cand.dm, 256, dtype=np.float32))
+    else:
+        dm_list = cuda.to_device(np.linspace(cand.dm-range_dm, cand.dm+range_dm, 256, dtype=np.float32))
     dmt_return = cuda.to_device(np.zeros((256, cand.data.shape[0]), dtype=np.float32))
     cand_data_in = cuda.to_device(np.array(cand.data.T, dtype=cand.data.dtype))
 


### PR DESCRIPTION
This lets your specify the dm range when creating DMTs.
This is very helpful when the incoming bursts are VERY narrow, a coarse dmt will completely miss it