### PR TITLE
np.int to np.int32 to avoid deprecation warning

### DIFF
--- a/bin/your_candmaker.py
+++ b/bin/your_candmaker.py
@@ -90,7 +90,7 @@ def cand2h5(cand_val):
     ) = cand_val
     if os.path.exists(str(kill_mask_path)):
         logger.info(f"Using mask {kill_mask_path}")
-        kill_chans = np.loadtxt(kill_mask_path, dtype=np.int)
+        kill_chans = np.loadtxt(kill_mask_path, dtype=np.int32)
     else:
         logger.debug("No Kill Mask")
 

--- a/bin/your_viewer.py
+++ b/bin/your_viewer.py
@@ -42,7 +42,6 @@ class Paint(Frame):
 
     # Define settings upon initialization. Here you can specify
     def __init__(self, master=None, dm=0):
-
         # parameters that you want to send through the Frame class.
         Frame.__init__(self, master)
 

--- a/your/utils/gpu.py
+++ b/your/utils/gpu.py
@@ -253,7 +253,7 @@ def gpu_dedisp_and_dmt_crop(cand, device=0):
 
     logger.debug("cand.dedisersed set!")
 
-    disp_time = np.zeros(shape=(cand_data_in.shape[0], 256), dtype=np.int)
+    disp_time = np.zeros(shape=(cand_data_in.shape[0], 256), dtype=np.int32)
     for idx, dms in enumerate(np.linspace(0, 2 * cand.dm, 256)):
         disp_time[:, idx] = np.round(
             -1

--- a/your/utils/heimdall.py
+++ b/your/utils/heimdall.py
@@ -100,7 +100,6 @@ class HeimdallManager:
         fswap=None,
         min_tscrunch_width=None,
     ):
-
         self.k = dada_key
         self.f = filename
         self.verbosity = verbosity

--- a/your/writer.py
+++ b/your/writer.py
@@ -66,7 +66,6 @@ class Writer:
         frequency_decimation_factor=1,
         replacement_policy="mean",
     ):
-
         self.your_object = your_object
         self.nstart = nstart
         if nsamp is None:


### PR DESCRIPTION
Numpy >1.20 gives warning if np.int is used instead of specific dtype. I have replaced necessary lines