### PR TITLE
Flexible DPI of output PNGs

### DIFF
--- a/bin/your_h5plotter.py
+++ b/bin/your_h5plotter.py
@@ -19,7 +19,7 @@ os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 matplotlib.use("Agg")
 
 
-def mapper(save, detrend_ft, publication, mad_filter, out_dir, h5_file):
+def mapper(save, detrend_ft, publication, mad_filter, dpi, out_dir, h5_file):
     # maps the variables so the function will be imap friendly
     plot_h5(
         h5_file=h5_file,
@@ -27,6 +27,7 @@ def mapper(save, detrend_ft, publication, mad_filter, out_dir, h5_file):
         detrend_ft=detrend_ft,
         publication=publication,
         mad_filter=mad_filter,
+        dpi=dpi,
         outdir=out_dir,
     )
 
@@ -64,6 +65,13 @@ if __name__ == "__main__":
         help="Directory to save pngs (default: h5 dir)",
         type=str,
         default=None,
+        required=False,
+    )
+    parser.add_argument(
+        "--dpi",
+        help="DPI of resulting PNG file (default: 300)",
+        type=int,
+        default=300,
         required=False,
     )
     parser.add_argument(
@@ -129,6 +137,7 @@ if __name__ == "__main__":
             values.no_detrend_ft,
             values.publish,
             values.mad_filter,
+            values.dpi,
             values.out_dir,
         )
 

--- a/your/utils/plotter.py
+++ b/your/utils/plotter.py
@@ -20,6 +20,7 @@ def plot_h5(
     detrend_ft=True,
     publication=False,
     mad_filter=False,
+    dpi=300,
     outdir=None,
 ):
     """
@@ -31,6 +32,7 @@ def plot_h5(
         save (bool): Save the file as a png
         detrend_ft (bool): detrend the frequency time plot
         publication (bool): make publication quality plot
+        dpi (int): DPI of output png (default: 300)
         outdir (str): Path to the save the files into.
 
     Returns:
@@ -122,7 +124,7 @@ def plot_h5(
                 filename = outdir + os.path.basename(h5_file)[:-3] + ".png"
             else:
                 filename = h5_file[:-3] + ".png"
-            plt.savefig(filename, bbox_inches="tight", dpi=300)
+            plt.savefig(filename, bbox_inches="tight", dpi=dpi)
         else:
             plt.close()
 


### PR DESCRIPTION
Adds ability to change the DPI of the PNGs created by your_h5plotter.py. Can specify integer DPI on the command line with "--dpi" flag.