### PR TITLE
Update CI + Reformat

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/bin/your_candmaker.py
+++ b/bin/your_candmaker.py
@@ -9,9 +9,9 @@ from rich.logging import RichHandler
 
 from your.utils.math import normalise
 
-os.environ[
-    "OPENBLAS_NUM_THREADS"
-] = "1"  # stop numpy multithreading regardless of the backend
+os.environ["OPENBLAS_NUM_THREADS"] = (
+    "1"  # stop numpy multithreading regardless of the backend
+)
 os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 

--- a/bin/your_combine_mocks.py
+++ b/bin/your_combine_mocks.py
@@ -330,9 +330,7 @@ def combine(
         if key in ("filelist", "filename", "center_freq", "fch1"):
             continue
         if key in ("ra_deg", "dec_deg", "gl", "gb"):
-            hpbw = (
-                57.3 * 3 * 10**8 / (low_header["center_freq"] * 10**6 * 200)
-            )  # deg
+            hpbw = 57.3 * 3 * 10**8 / (low_header["center_freq"] * 10**6 * 200)  # deg
             if np.abs(low_header[key] - up_header[key]) > 0.1 * hpbw:
                 raise ValueError(
                     f"Value of {key} in the two bands differ by more than 10% FWHM"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ numba>=0.48.0
 astropy>=4.0
 pandas>=1.0.3
 rich>=8.0
+setuptools

--- a/your/formats/psrfits.py
+++ b/your/formats/psrfits.py
@@ -4,7 +4,7 @@
 Collect PSRFITS information, emulating behaviour of PRESTO.
 Read PSRFITS data.
 
-Original Source: https://github.com/scottransom/presto/blob/master/python/presto/psrfits.py 
+Original Source: https://github.com/scottransom/presto/blob/master/python/presto/psrfits.py
 """
 import logging
 import os

--- a/your/formats/psrfits.py
+++ b/your/formats/psrfits.py
@@ -124,7 +124,10 @@ class PsrfitsFile(object):
 
         # Unifying properties with pysigproc
         self.npol = self.npoln
-        self.bw = self.specinfo.BW
+        # Earlier versions of SpectraInfo returned a float64 here,
+        # later versions float32
+        # a np.float64 is needed to log the json dump in fitewriter.py
+        self.bw = np.float64(self.specinfo.BW)
         self.cfreq = self.header["OBSFREQ"]
         self.fch1 = self.freqs[0]  # self.cfreq - self.bw / 2.0  # Verify
         self.foff = self.bw / self.nchan
@@ -176,6 +179,8 @@ class PsrfitsFile(object):
              float: Native channel bandwidth
 
         """
+        with open("psrfits_native_foff.txt", "w") as file:
+            file.write(f"{self.bw} {type(self.bw)=}")
         return self.bw / self.nchan
 
     def native_nchans(self):

--- a/your/utils/heimdall.py
+++ b/your/utils/heimdall.py
@@ -42,8 +42,7 @@ def generate_dm_list(
     while dm_list[-1] < dm_end:
         k = c + tol**2 * a**2 * dm_list[-1] ** 2
         dm = (
-            b * dm_list[-1]
-            + math.sqrt(-(a**2) * b * dm_list[-1] ** 2 + (a**2 + b) * k)
+            b * dm_list[-1] + math.sqrt(-(a**2) * b * dm_list[-1] ** 2 + (a**2 + b) * k)
         ) / (a**2 + b)
         dm_list.append(dm)
     return dm_list


### PR DESCRIPTION
- Update to test against Python 3.10-3.13
- Reformat with new Black
- Fix fits header being read in as np.float32, causing a failure in dumping info to log
- Update python-publish to use Python 3.11