### PR TITLE
Fix: Remove deprecated setup.py install and replace with pip install.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,7 +22,7 @@ jobs:
           pip install -r requirements.txt
       - name: Install it
         run: |
-          python setup.py install
+          pip install .
       - name: Black Check
         run: |
           pip install black


### PR DESCRIPTION
… See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html#summary. 
This will allow the CI test to install your.